### PR TITLE
Update to current Mentat interfaces

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -62,7 +62,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "edn"
 version = "0.1.0"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -164,7 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -172,7 +172,7 @@ name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -188,19 +188,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -211,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "iovec"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -341,26 +342,26 @@ dependencies = [
 
 [[package]]
 name = "mentat"
-version = "0.5.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+version = "0.6.0"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "edn 0.1.0 (git+https://github.com/mozilla/mentat.git)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query_parser 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query_translator 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_tolstoy 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query_translator 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_tolstoy 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -369,10 +370,10 @@ dependencies = [
 [[package]]
 name = "mentat_core"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "edn 0.1.0 (git+https://github.com/mozilla/mentat.git)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "enum-set 0.0.6 (git+https://github.com/rnewman/enum-set)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -383,15 +384,15 @@ dependencies = [
 [[package]]
 name = "mentat_db"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
- "edn 0.1.0 (git+https://github.com/mozilla/mentat.git)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
  "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tabwriter 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -401,95 +402,95 @@ dependencies = [
 [[package]]
 name = "mentat_parser_utils"
 version = "0.1.0"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
  "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "edn 0.1.0 (git+https://github.com/mozilla/mentat.git)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mentat_query"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
- "edn 0.1.0 (git+https://github.com/mozilla/mentat.git)",
- "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
 ]
 
 [[package]]
 name = "mentat_query_algebrizer"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
  "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
- "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
 ]
 
 [[package]]
 name = "mentat_query_parser"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
  "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "edn 0.1.0 (git+https://github.com/mozilla/mentat.git)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
  "maplit 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
 ]
 
 [[package]]
 name = "mentat_query_projector"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
  "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
- "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mentat_query_sql"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
- "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mentat_query_translator"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
  "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
- "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
 ]
 
 [[package]]
 name = "mentat_sql"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
  "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
- "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -497,14 +498,14 @@ dependencies = [
 [[package]]
 name = "mentat_tolstoy"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
- "edn 0.1.0 (git+https://github.com/mozilla/mentat.git)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -516,21 +517,21 @@ dependencies = [
 [[package]]
 name = "mentat_tx"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
- "edn 0.1.0 (git+https://github.com/mozilla/mentat.git)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
 ]
 
 [[package]]
 name = "mentat_tx_parser"
 version = "0.0.1"
-source = "git+https://github.com/mozilla/mentat.git#6ed5413cd42e2c4bba4d38dc57063168c32112dd"
+source = "git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords#2c149182fa4a72c619843c5f0953c88804480735"
 dependencies = [
  "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "edn 0.1.0 (git+https://github.com/mozilla/mentat.git)",
+ "edn 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
- "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git)",
- "mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
+ "mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
 ]
 
 [[package]]
@@ -548,7 +549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -591,7 +592,7 @@ dependencies = [
  "num-complex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -634,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-bigint 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -729,10 +730,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "relay"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -833,15 +834,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "store"
 version = "0.1.0"
 dependencies = [
- "edn 0.1.0 (git+https://github.com/mozilla/mentat.git)",
  "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
  "ffi-utils 0.1.0",
  "jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "mentat 0.5.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git)",
- "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mentat 0.6.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -903,8 +899,8 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -918,7 +914,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -927,7 +923,7 @@ name = "tokio-proto"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -944,20 +940,18 @@ name = "tokio-service"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "toodle"
 version = "0.1.0"
 dependencies = [
- "edn 0.1.0 (git+https://github.com/mozilla/mentat.git)",
  "error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)",
  "ffi-utils 0.1.0",
  "jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "mentat 0.5.1 (git+https://github.com/mozilla/mentat.git)",
- "mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)",
+ "mentat 0.6.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)",
  "rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "store 0.1.0",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1086,19 +1080,19 @@ dependencies = [
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1645a65a99c7c8d345761f4b75a6ffe5be3b3b27a93ee731fccc5050ba6be97c"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
-"checksum edn 0.1.0 (git+https://github.com/mozilla/mentat.git)" = "<none>"
+"checksum edn 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum enum-set 0.0.6 (git+https://github.com/rnewman/enum-set)" = "<none>"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum error-chain 0.11.0 (git+https://github.com/rnewman/error-chain?branch=rnewman/sync)" = "<none>"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
+"checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
-"checksum hyper 0.11.15 (registry+https://github.com/rust-lang/crates.io-index)" = "4d6105c5eeb03068b10ff34475a0d166964f98e7b9777cc34b342a225af9b87c"
-"checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
+"checksum hyper 0.11.16 (registry+https://github.com/rust-lang/crates.io-index)" = "6a82c41828dd6f271f4d6ebc3f1db78239a4b2b3d355dfdb5f8bbf55f004463a"
+"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b07332223953b5051bceb67e8c4700aa65291535568e1f12408c43c4a42c0394"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum jni 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cffc930ce6a38a4013e30567b559bdc79f601013ba4a81e65dbda9207263efd4"
@@ -1117,20 +1111,20 @@ dependencies = [
 "checksum maplit 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "22593015b8df7747861c69c28acd32589fb96c1686369f3b661d12e409d4cf65"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
-"checksum mentat 0.5.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_query_parser 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_query_translator 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_tolstoy 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
-"checksum mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git)" = "<none>"
+"checksum mentat 0.6.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_core 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_db 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_parser_utils 0.1.0 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_query 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_query_algebrizer 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_query_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_query_projector 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_query_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_query_translator 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_sql 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_tolstoy 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_tx 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
+"checksum mentat_tx_parser 0.0.1 (git+https://github.com/mozilla/mentat.git?branch=rnewman/simplify-keywords)" = "<none>"
 "checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
 "checksum mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "75f72a93f046f1517e3cfddc0a096eb756a2ba727d36edc8227dee769a50a9b0"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
@@ -1140,7 +1134,7 @@ dependencies = [
 "checksum num-complex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "58de7b4bf7cf5dbecb635a5797d489864eadd03b107930cbccf9e0fd7428b47c"
 "checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
-"checksum num-rational 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7cb72a95250d8a370105c828f388932373e0e94414919891a0f945222310fe"
+"checksum num-rational 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "0b950f75e042fdd710460084d19c8efdcd72d65183ead8ecd04b90483f5a55d2"
 "checksum num-traits 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "9936036cc70fe4a8b2d338ab665900323290efb03983c86cbe235ae800ad8017"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58d25b6c0e47b20d05226d288ff434940296e7e2f8b877975da32f862152241f"
@@ -1153,7 +1147,7 @@ dependencies = [
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
-"checksum relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f301bafeb60867c85170031bdb2fcf24c8041f33aee09e7b116a58d4e9f781c5"
+"checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum rusqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffaf393ccdac5580092a4d8eb2edffbffe9a8c4484c62d8a0fcac99bc3718566"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,21 +20,13 @@ jni = { version = "0.5", default-features = false }
 
 [dependencies]
 error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
-libc = "0.2.32"
-time = "0.1.38"
+libc = "0.2"
+time = "0.1"
 uuid = { version = "0.5", features = ["v4"] }
-
-[dependencies.edn]
-git = "https://github.com/mozilla/mentat.git"
-branch = "master"
 
 [dependencies.mentat]
 git = "https://github.com/mozilla/mentat.git"
-branch = "master"
-
-[dependencies.mentat_core]
-git = "https://github.com/mozilla/mentat.git"
-branch = "master"
+branch = "rnewman/simplify-keywords"
 
 [dependencies.store]
 path = "store"

--- a/rust/src/ctypes.rs
+++ b/rust/src/ctypes.rs
@@ -8,18 +8,25 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+use std::os::raw::c_char;
+use std::ptr;
+
 use ffi_utils::strings::{
     string_to_c_char,
     c_char_to_string,
 };
-use std::os::raw::c_char;
-use std::ptr;
 
-use mentat_core::Uuid;
-use time::Timespec;
+use time::{
+    Timespec,
+};
+
+use mentat::{
+    Uuid,
+};
 
 use items::{
-    Item, Items
+    Item,
+    Items,
 };
 
 #[repr(C)]

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -10,7 +10,7 @@
 
 use mentat;
 
-use store::errors as store_error;
+use store;
 
 error_chain! {
     types {
@@ -18,7 +18,7 @@ error_chain! {
     }
 
     links {
-        StoreError(store_error::Error, store_error::ErrorKind);
+        StoreError(store::errors::Error, store::errors::ErrorKind);
         MentatError(mentat::errors::Error, mentat::errors::ErrorKind);
     }
 

--- a/rust/src/items.rs
+++ b/rust/src/items.rs
@@ -8,27 +8,29 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use libc::size_t;
 use std::os::raw::{
     c_char,
     c_int,
 };
 use std::ptr;
 
-pub use edn::{
-    DateTime,
-    Utc,
-};
-use mentat_core::{
-    Uuid,
-};
-use time::Timespec;
-
 use ffi_utils::strings::{
     string_to_c_char,
     c_char_to_string,
 };
-use labels::Label;
+
+use libc::size_t;
+
+use time::Timespec;
+
+use mentat::{
+    Uuid,
+};
+
+use labels::{
+    Label,
+};
+
 use store::{
     Entity,
 };

--- a/rust/src/labels.rs
+++ b/rust/src/labels.rs
@@ -10,15 +10,18 @@
 
 use std::os::raw::c_char;
 
-use mentat_core::TypedValue;
-
 use ffi_utils::strings::{
     string_to_c_char,
     c_char_to_string,
 };
+
+use mentat::{
+    TypedValue,
+};
+
 use store::{
     Entity,
-    ToInner
+    ToInner,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/rust/store/Cargo.toml
+++ b/rust/store/Cargo.toml
@@ -6,8 +6,7 @@ workspace = ".."
 
 [dependencies]
 error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
-ordered-float = "0.5"
-time = "0.1.38"
+time = "0.1"
 uuid = { version = "0.5", features = ["v4"] }
 
 [target.'cfg(target_os="android")'.dependencies]
@@ -20,23 +19,7 @@ features = ["bundled", "limits"]
 
 [dependencies.mentat]
 git = "https://github.com/mozilla/mentat.git"
-branch = "master"
-
-[dependencies.edn]
-git = "https://github.com/mozilla/mentat.git"
-branch = "master"
-
-[dependencies.mentat_query]
-git = "https://github.com/mozilla/mentat.git"
-branch = "master"
-
-[dependencies.mentat_core]
-git = "https://github.com/mozilla/mentat.git"
-branch = "master"
-
-[dependencies.mentat_db]
-git = "https://github.com/mozilla/mentat.git"
-branch = "master"
+branch = "rnewman/simplify-keywords"
 
 [dependencies.ffi-utils]
 path = "../ffi-utils"


### PR DESCRIPTION
Much less code, much less fragmented imports, fewer explicit dependencies. Tests pass.

Note that this temporarily points to [my fix-the-world PR](https://github.com/mozilla/mentat/pull/537), which needs to land alongside this.