### PR TITLE
Closes #27: Address incorrect calculation of micro_seconds on Timespec to_typed_v…

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -22,7 +22,6 @@ extern crate store;
 
 use std::ffi::CString;
 use std::os::raw::c_char;
-use std::str::FromStr;
 
 use ffi_utils::log;
 use ffi_utils::strings::{

--- a/rust/store/src/lib.rs
+++ b/rust/store/src/lib.rs
@@ -120,7 +120,7 @@ impl ToTypedValue for f64 {
 impl ToTypedValue for Timespec {
     fn to_typed_value(&self) -> TypedValue {
         // TODO: shouldn't that be / 1000?!
-        let micro_seconds = (self.sec * 1000000) + i64::from((self.nsec * 1000));
+        let micro_seconds = (self.sec * 1000000) + i64::from((self.nsec / 1000));
         TypedValue::instant(micro_seconds)
     }
 }
@@ -274,5 +274,24 @@ impl Store {
             conn:Arc::new(RwLock::new(c)),
             uri: uri,
         })
+    }
+}
+
+
+mod test {
+    use super::{
+        ToTypedValue,
+        TypedValue,
+        Timespec,
+    };
+
+    #[test]
+    fn test_timespec_to_typed_value() {
+        let timespec = Timespec {
+            sec: 1518434618,
+            nsec: 740993000,
+        };
+        let typed_value: TypedValue = timespec.to_typed_value();
+        assert_eq!(typed_value, TypedValue::instant(1518434618740993));
     }
 }

--- a/rust/store/src/lib.rs
+++ b/rust/store/src/lib.rs
@@ -119,8 +119,7 @@ impl ToTypedValue for f64 {
 
 impl ToTypedValue for Timespec {
     fn to_typed_value(&self) -> TypedValue {
-        // TODO: shouldn't that be / 1000?!
-        let micro_seconds = (self.sec * 1000000) + i64::from((self.nsec / 1000));
+        let micro_seconds = (self.sec * 1_000_000) + i64::from((self.nsec / 1_000));
         TypedValue::instant(micro_seconds)
     }
 }
@@ -277,7 +276,7 @@ impl Store {
     }
 }
 
-
+#[cfg(test)]
 mod test {
     use super::{
         ToTypedValue,
@@ -289,7 +288,7 @@ mod test {
     fn test_timespec_to_typed_value() {
         let timespec = Timespec {
             sec: 1518434618,
-            nsec: 740993000,
+            nsec: 740993537,
         };
         let typed_value: TypedValue = timespec.to_typed_value();
         assert_eq!(typed_value, TypedValue::instant(1518434618740993));


### PR DESCRIPTION
…alue

