### PR TITLE
Attempt to get toodle working with a recent mentat.

### DIFF
--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -12,7 +12,7 @@ use rusqlite;
 
 use mentat::errors as mentat;
 use mentat::edn::UuidParseError;
-use mentat::NamespacedKeyword;
+use mentat::Keyword;
 
 error_chain! {
     types {
@@ -29,7 +29,7 @@ error_chain! {
     }
 
     errors {
-        UnknownAttribute(keyword: NamespacedKeyword) {
+        UnknownAttribute(keyword: Keyword) {
             description("Keyword not found")
             display("Keyword {} not found", keyword)
         }

--- a/rust/src/labels.rs
+++ b/rust/src/labels.rs
@@ -9,7 +9,7 @@
 // specific language governing permissions and limitations under the License.
 
 use mentat::{
-    TypedValue,
+    Binding,
 };
 
 use utils::{
@@ -25,11 +25,11 @@ pub struct Label {
 }
 
 impl Label {
-    pub fn from_row(row: &Vec<TypedValue>) -> Option<Label> {
+    pub fn from_row(row: &Vec<Binding>) -> Option<Label> {
         Some(Label {
-            id: row[0].clone().to_inner(),
-            name: row[1].clone().to_inner(),
-            color: row[2].clone().to_inner()
+            id: row[0].clone().val().expect("typed value").to_inner(),
+            name: row[1].clone().val().expect("typed value").to_inner(),
+            color: row[2].clone().val().expect("typed value").to_inner(),
         })
     }
 }

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -21,7 +21,7 @@ use std::fmt::{
 use time::Timespec;
 
 use mentat::{
-    NamespacedKeyword,
+    Keyword,
     Entid,
     TypedValue,
     Uuid,
@@ -72,7 +72,7 @@ impl Into<Entid> for Entity {
     }
 }
 
-impl ToTypedValue for NamespacedKeyword {
+impl ToTypedValue for Keyword {
     fn to_typed_value(&self) -> TypedValue {
         self.clone().into()
     }
@@ -98,7 +98,7 @@ impl ToTypedValue for f64 {
 
 impl ToTypedValue for Timespec {
     fn to_typed_value(&self) -> TypedValue {
-        let micro_seconds = (self.sec * 1_000_000) + i64::from((self.nsec / 1_000));
+        let micro_seconds = (self.sec * 1_000_000) + i64::from(self.nsec / 1_000);
         TypedValue::instant(micro_seconds)
     }
 }

--- a/rust/toodle_ffi/src/ctypes.rs
+++ b/rust/toodle_ffi/src/ctypes.rs
@@ -11,6 +11,8 @@
 use std::os::raw::c_char;
 use std::ptr;
 
+use utils::c_char_to_string;
+
 use time::{
     Timespec,
 };
@@ -20,7 +22,6 @@ use mentat::{
 };
 
 use mentat_ffi::utils::strings::{
-    c_char_to_string,
     string_to_c_char,
 };
 

--- a/rust/toodle_ffi/src/lib.rs
+++ b/rust/toodle_ffi/src/lib.rs
@@ -17,6 +17,8 @@ extern crate toodle;
 mod ctypes;
 mod utils;
 
+use utils::c_char_to_string;
+
 use libc::{ c_int, size_t, time_t };
 use std::ffi::CString;
 use std::os::raw::{
@@ -26,7 +28,6 @@ use std::os::raw::{
 use time::Timespec;
 
 pub use mentat::{
-    Store,
     Uuid,
 };
 
@@ -38,7 +39,6 @@ pub use mentat_ffi::{
 };
 use mentat_ffi::utils::log;
 use mentat_ffi::utils::strings::{
-    c_char_to_string,
     string_to_c_char,
 };
 
@@ -46,6 +46,7 @@ use toodle::{
     Item,
     Label,
     Toodle,
+    Store
 };
 use ctypes::{
     ItemC,

--- a/rust/toodle_ffi/src/utils.rs
+++ b/rust/toodle_ffi/src/utils.rs
@@ -7,6 +7,13 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
+use std::os::raw::{
+    c_char,
+};
+use mentat_ffi::utils::strings::{
+    c_char_to_string as mentat_c_char_to_string,
+};
+
 pub mod time {
     use time::Timespec;
     use libc::time_t;
@@ -17,4 +24,8 @@ pub mod time {
             false => Some(Timespec::new(unsafe { *timestamp as i64 }, 0))
         }
     }
+}
+
+pub fn c_char_to_string(cchar: *const c_char) -> String {
+    mentat_c_char_to_string(cchar).to_string()
 }


### PR DESCRIPTION
This isn't actually a PR, because it doesn't actually work :)
However, putting it up as a PR seems a good way to get feedback.
It also isn't strictly necessary to keep toodle alive in this way - as
Emily mentioned, simply pinning it to an earlier mentat revision would
work, but I took this on as an opportunity to better understand mentat.

The biggest set of changes here seems to be due to mentat wrapping a
TypedValue in a Binding enum. The simplest fix to that is to use the
.val() method on a binding, but that returns an Option, but many things
that want to use the TypedValue don't handle options - so I simply use
.val().expect() and hope nothing panics :) Is there a better way to handle
this?

The next issue I struck was due to toodle.initialize() not being called in
any of the tests. I'm a bit confused by that because it's not clear to me
how mentat changes would affect that.

And finally, while most tests now pass, all tests which end up calling
fetch_labels_for_item() fail - it always returns zero items. Best I can tell,
the into_rel_result() call there is returning a RelResult with a width of 3
but an empty vec - so it's not working even before my dodgy
/rows.iter()/rows.into_iter()/ change in that same function.

I don't mind poking more at this but also don't mind abandoning it either,
but I would appreciate a little feedback on the changes I made to help me
better understand what is going on.

ping @fluffyemily :)